### PR TITLE
Add Changeset Logic to Structures

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,10 +3,6 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -24,6 +20,17 @@ version = "0.5.5"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "2276ac65f1e236e0a6ea70baff3f62ad4c625345"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.2"
+
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -31,9 +38,11 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -5,4 +5,5 @@ version = "0.1.0"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DesignByContract.jl
+++ b/src/DesignByContract.jl
@@ -3,7 +3,12 @@ using MacroTools
 include("./agreements.jl")
 include("./functionContract.jl")
 include("./loopContract.jl")
+include("./changesetAgreement.jl")
 
-export @contract, @loopinvariant, setAgreementEnabling, ContractBreachException
+export @contract, @loopinvariant, # Contracts
+       setAgreementEnabling, # Configuration
+       ContractBreachException, # Errors
+       Changeset, applyChangeset, changeset, # Changeset
+       InvalidChangesetException # Changeset Error
 
 end # module

--- a/src/changesetAgreement.jl
+++ b/src/changesetAgreement.jl
@@ -2,7 +2,7 @@ struct Changeset{T}
     value :: T
     types :: Dict
     changes :: Base.Iterators.Pairs 
-    errors :: Vector
+    errors :: Vector{Tuple{Symbol, String}}
     isValid :: Bool
 end
 
@@ -12,7 +12,7 @@ end
 
 function Base.show(io :: IO, exception :: InvalidChangesetException)
     println(io, "Invalid Changeset")
-    show(io, exception.errors)
+    show(io, exception.changeset.errors)
 end
 
 function Base.show(io::IO, m::Changeset{T}) where T
@@ -54,7 +54,7 @@ function castFields(object :: T; args...) :: Changeset{T} where T
     for key in keys(args)
         if !(haskey(nameTypeDict, key)) || typeof(args[key]) != nameTypeDict[key]
             isValid = false
-            append!(errors, (key, "Invalid cast"))
+            errors = vcat(errors, [(key, "Invalid cast")])
         end
     end
     return Changeset{T}(

--- a/src/changesetAgreement.jl
+++ b/src/changesetAgreement.jl
@@ -1,0 +1,71 @@
+struct Changeset{T}
+    value :: T
+    types :: Dict
+    changes :: Base.Iterators.Pairs 
+    errors :: Vector
+    isValid :: Bool
+end
+
+struct InvalidChangesetException{T} <: Exception
+    changeset :: Changeset{T}
+end
+
+function Base.show(io :: IO, exception :: InvalidChangesetException)
+    println(io, "Invalid Changeset")
+    show(io, exception.errors)
+end
+
+function Base.show(io::IO, m::Changeset{T}) where T
+    println(io, "Changeset{$(T)} {")
+    println(io, "   data: $(m.value)")
+    println(io, "   types: $(m.types)")
+    println(io, "   changes: $(m.changes)")
+    println(io, "   errors: $(m.errors)")
+    println(io, "   isValid: $(m.isValid)")
+    println(io, "}")
+end
+
+function __init__()
+    Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+        if typeof(exc) == MethodError 
+            printstyled(io, "\n\nDid you start the structure with @with_kw?\n", color=:cyan)
+        end
+    end
+end
+
+function applyChangeset(changeset :: Changeset{T}) :: T where T
+    if changeset.isValid
+        T(changeset.value, changeset.changes)
+    else
+       changeset |> InvalidChangesetException |> throw
+    end
+end
+
+function buildNameTypeDictionary(structure :: DataType) :: Dict{Symbol, DataType}
+    names = structure |> fieldnames |> collect
+    types = structure |> fieldtypes |> collect
+    return hcat(names, types) |> eachrow .|> Tuple |> Dict 
+end
+
+function castFields(object :: T; args...) :: Changeset{T} where T
+    nameTypeDict = buildNameTypeDictionary(T)
+    isValid = true
+    errors = []
+    for key in keys(args)
+        if !(haskey(nameTypeDict, key)) || typeof(args[key]) != nameTypeDict[key]
+            isValid = false
+            append!(errors, (key, "Invalid cast"))
+        end
+    end
+    return Changeset{T}(
+        object,
+        nameTypeDict,
+        args,
+        errors,
+        isValid
+    )
+end
+
+function changeset(object :: T; args...) :: Changeset{T} where T
+    castFields(object; args...)
+end

--- a/test/changesetTests.jl
+++ b/test/changesetTests.jl
@@ -12,23 +12,29 @@ struct KeywordlessStruct
     c::String
 end
 
+newA = 2
+newB = 3.0
+newC = "new sample string"
+
+sampleKeywordlessStructure = KeywordlessStruct(1, 2.0, "sample string")
 sampleKeywordStructure = KeywordStruct(1, 2.0, "sample string")
 
+structureChangeset = changeset(sampleKeywordStructure; a = newA, b = newB, c = newC)
+structureKeylessChangeset =
+    changeset(sampleKeywordlessStructure; a = newA, b = newB, c = newC)
+
+invalidA = ""
+invalidB = rand(Int64)
+invalidC = rand(Float64)
+
+invalidChangeset =
+    changeset(sampleKeywordStructure; a = invalidA, b = invalidB, c = invalidC)
+
 @testset "Creates Changeset for KeywordStruct" begin
-    newA = 2
-    newB = 3.0
-    newC = "new sample string"
-    structureChangeset = changeset(sampleKeywordStructure; a=newA, b=newB, c=newC)
 
     @test structureChangeset.isValid
     @test structureChangeset.changes == Dict(:a => newA, :b => newB, :c => newC)
     @test structureChangeset.errors == []
-
-    invalidA = ""
-    invalidB = 2
-    invalidC = 4.0
-
-    invalidChangeset = changeset(sampleKeywordStructure; a=invalidA, b=invalidB, c=invalidC)
 
     @test !invalidChangeset.isValid
     @test invalidChangeset.changes == Dict(:a => invalidA, :b => invalidB, :c => invalidC)
@@ -36,18 +42,7 @@ sampleKeywordStructure = KeywordStruct(1, 2.0, "sample string")
 end
 
 @testset "Applies Changeset for KeywordStruct" begin
-    newA = 2
-    newB = 3.0
-    newC = "new sample string"
-    structureChangeset = changeset(sampleKeywordStructure; a=newA, b=newB, c=newC)
-
     @test applyChangeset(structureChangeset) == KeywordStruct(newA, newB, newC)
-
-    invalidA = ""
-    invalidB = 2
-    invalidC = 4.0
-
-    invalidChangeset = changeset(sampleKeywordStructure; a=invalidA, b=invalidB, c=invalidC)
 
     @test_throws InvalidChangesetException{KeywordStruct} applyChangeset(invalidChangeset)
 
@@ -60,20 +55,58 @@ end
     end
 end
 
+@testset "Shows Changeset correctly formatted" begin
+    b = IOBuffer()
+    show(b, structureChangeset)
+    outString = String(take!(b))
 
-sampleKeywordlessStructure = KeywordlessStruct(1, 2.0, "sample string")
+    @test contains(
+        outString,
+        "   types: [\n      a => Int64\n      b => Float64\n      c => String\n   ]",
+    )
+    @test contains(
+        outString,
+        "   changes: [\n      a => $(newA)\n      b => $(newB)\n      c => $(newC)\n   ]",
+    )
+    @test contains(outString, "errors: []")
+    @test contains(outString, "isValid: true")
+    @test contains(outString, "Changeset{KeywordStruct}")
 
+    b = IOBuffer()
+    show(b, invalidChangeset)
+    outString = String(take!(b))
+
+    @test contains(
+        outString,
+        "   types: [\n      a => Int64\n      b => Float64\n      c => String\n   ]",
+    )
+    @test contains(
+        outString,
+        "   changes: [\n      a => $(invalidA)\n      b => $(invalidB)\n      c => $(invalidC)\n   ]",
+    )
+    @test contains(
+        outString,
+        "errors: [\n      a => Invalid cast\n      b => Invalid cast\n      c => Invalid cast\n   ]",
+    )
+    @test contains(outString, "isValid: false")
+    @test contains(outString, "Changeset{KeywordStruct}")
+end
+
+@testset "Shows Invalid Changeset Error correctly formatted" begin
+    try
+        applyChangeset(invalidChangeset)
+    catch e
+        b = IOBuffer()
+        showerror(b, e)
+        @test contains(String(take!(b)), "Invalid Changeset\n")
+    end
+end
 
 @testset "Applying a Changeset for KeywordlessStruct throws an error" begin
-    newA = 2
-    newB = 3.0
-    newC = "new sample string"
-    structureChangeset = changeset(sampleKeywordlessStructure; a=newA, b=newB, c=newC)
-
-    @test_throws MethodError applyChangeset(structureChangeset)
+    @test_throws MethodError applyChangeset(structureKeylessChangeset)
 
     try
-        applyChangeset(structureChangeset)
+        applyChangeset(structureKeylessChangeset)
     catch e
         b = IOBuffer()
         showerror(b, e)

--- a/test/changesetTests.jl
+++ b/test/changesetTests.jl
@@ -1,0 +1,82 @@
+using Parameters
+
+@with_kw struct KeywordStruct
+    a::Int64
+    b::Float64
+    c::String
+end
+
+struct KeywordlessStruct
+    a::Int64
+    b::Float64
+    c::String
+end
+
+sampleKeywordStructure = KeywordStruct(1, 2.0, "sample string")
+
+@testset "Creates Changeset for KeywordStruct" begin
+    newA = 2
+    newB = 3.0
+    newC = "new sample string"
+    structureChangeset = changeset(sampleKeywordStructure; a=newA, b=newB, c=newC)
+
+    @test structureChangeset.isValid
+    @test structureChangeset.changes == Dict(:a => newA, :b => newB, :c => newC)
+    @test structureChangeset.errors == []
+
+    invalidA = ""
+    invalidB = 2
+    invalidC = 4.0
+
+    invalidChangeset = changeset(sampleKeywordStructure; a=invalidA, b=invalidB, c=invalidC)
+
+    @test !invalidChangeset.isValid
+    @test invalidChangeset.changes == Dict(:a => invalidA, :b => invalidB, :c => invalidC)
+    @test invalidChangeset.errors == [:a, :b, :c] .|> var -> (var, "Invalid cast")
+end
+
+@testset "Applies Changeset for KeywordStruct" begin
+    newA = 2
+    newB = 3.0
+    newC = "new sample string"
+    structureChangeset = changeset(sampleKeywordStructure; a=newA, b=newB, c=newC)
+
+    @test applyChangeset(structureChangeset) == KeywordStruct(newA, newB, newC)
+
+    invalidA = ""
+    invalidB = 2
+    invalidC = 4.0
+
+    invalidChangeset = changeset(sampleKeywordStructure; a=invalidA, b=invalidB, c=invalidC)
+
+    @test_throws InvalidChangesetException{KeywordStruct} applyChangeset(invalidChangeset)
+
+    try
+        applyChangeset(invalidChangeset)
+    catch e
+        b = IOBuffer()
+        showerror(b, e)
+        @test contains(String(take!(b)), "Invalid Changeset")
+    end
+end
+
+
+sampleKeywordlessStructure = KeywordlessStruct(1, 2.0, "sample string")
+
+
+@testset "Applying a Changeset for KeywordlessStruct throws an error" begin
+    newA = 2
+    newB = 3.0
+    newC = "new sample string"
+    structureChangeset = changeset(sampleKeywordlessStructure; a=newA, b=newB, c=newC)
+
+    @test_throws MethodError applyChangeset(structureChangeset)
+
+    try
+        applyChangeset(structureChangeset)
+    catch e
+        b = IOBuffer()
+        showerror(b, e)
+        @test contains(String(take!(b)), "Did you start the structure with @with_kw?")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,6 @@ include("./loopInnerVarianceTests.jl")
 
 # Agreement Disabling
 include("./agreementDisablingTests.jl")
+
+# Changeset
 include("./changesetTests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,4 @@ include("./loopInnerVarianceTests.jl")
 
 # Agreement Disabling
 include("./agreementDisablingTests.jl")
+include("./changesetTests.jl")


### PR DESCRIPTION
# What´s this about?

`Changesets` are a form of mediating structure changes. This is introduced as a sleek and neat way of state management in `Elixir.Ecto`. It is a good option to implement contracts for structures, but requires out of the box guideline following.

# Approach

`Changesets` require a number of fields to work:

- `isValid`: Whether the `Changeset` is valid or not.
- `types`: A dictionary of fields to types.
- `errors`: A dictionary mapping errors to fields.
- `type`: The underlying structure type.
- `changes`: A list with the evaluated changes.

I, thus, propose the addition of a macro that will implement a method for a given structure: `castFields`: computes a `Changeset` for a given structure and parameter dictionary. I also want to use multiple dispatch to enable custom `changeset` functions that validate specific fields and cast the errors to them. 