### PR TITLE
New structure invariant implementation

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,10 +3,6 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -24,6 +20,17 @@ version = "0.5.5"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "2276ac65f1e236e0a6ea70baff3f62ad4c625345"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.2"
+
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -31,9 +38,11 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -5,4 +5,5 @@ version = "0.1.0"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DesignByContract.jl
+++ b/src/DesignByContract.jl
@@ -1,9 +1,10 @@
 module DesignByContract
-using MacroTools
+using MacroTools, Parameters
 include("./agreements.jl")
 include("./functionContract.jl")
 include("./loopContract.jl")
+include("./structureInvariant.jl")
 
-export @contract, @loopinvariant, setAgreementEnabling, ContractBreachException
+export @contract, @loopinvariant, @structInvariant, initialize, change, setDefaultStructureName, setAgreementEnabling, ContractBreachException
 
 end # module

--- a/src/agreements.jl
+++ b/src/agreements.jl
@@ -44,6 +44,7 @@ struct ContractBreachException <: Exception
     name::Union{String,Nothing}
     expression::String
     breachMessage::String
+    # TODO: Add agreement type for a better error message
 end
 
 function Base.showerror(io::IO, e::ContractBreachException)

--- a/src/structureInvariant.jl
+++ b/src/structureInvariant.jl
@@ -49,12 +49,11 @@ macro structInvariant(expr...)
     structureAgreement(structExpr)
 end
 
-function change(structure :: Any;)
-    error("`change` not implemented for $(typeof(structure))")
+function change(structure :: Any; changes...)
+    error("`change` not implemented for $(structure)")
 end
 
 function initialize(mod :: Type; changes...)
     structure = mod(;changes...)
-    # TODO: Find a way to use a global scoped function
     return change(structure;)
 end

--- a/src/structureInvariant.jl
+++ b/src/structureInvariant.jl
@@ -1,0 +1,60 @@
+structureReferenceName = :structure
+
+function setDefaultStructureName(newName :: Symbol)
+    global structureReferenceName
+    structureReferenceName = newName
+end
+
+function addStructureInvariant!(structureBody :: Expr, agreement :: Agreement)
+    newExpr = Expr(:block)
+
+    newMacroexpandExpr = Expr(:macrocall)
+    newStructExpr = Expr(:macrocall) 
+    newStructExpr.args = [Symbol("@with_kw"), LineNumberNode(0, :none), structureBody]
+    newMacroexpandExpr.args = [Symbol("@macroexpand"), LineNumberNode(0, :none), newStructExpr]
+
+    checks = createCheckExpressions(agreement)
+
+    functionExpr = :(
+        function DesignByContract.change($(structureReferenceName) :: $(Symbol(agreement.name)); changes...)
+            $(structureReferenceName) =
+                $(Symbol(agreement.name))($(structureReferenceName); changes...)
+            $(checks...)
+            return $(structureReferenceName)
+        end
+    )
+
+    newExpr.args = [eval(newMacroexpandExpr), functionExpr]
+
+    esc(newExpr)
+end
+
+macro structInvariant(expr...)
+    @assert length(expr) == 2 "Incorrect amount of parameters"
+
+    validationExpressions = expr[1].args
+    @assert length(validationExpressions) > 0 "No invariants set"
+    
+    structExpr = expr[2]
+    @assert structExpr.head == :struct "Not the correct parameter format"
+    structName = structExpr.args[2] |> string
+    
+    structureAgreement = Agreement(structInvariant, addStructureInvariant!, structName)
+    if typeof(validationExpressions[1]) == Expr
+        structureAgreement.expressions = collect(validationExpressions)
+    else
+        structureAgreement.expressions = [Expr(:call, validationExpressions...)]
+    end
+
+    structureAgreement(structExpr)
+end
+
+function change(structure :: Any;)
+    error("`change` not implemented for $(typeof(structure))")
+end
+
+function initialize(mod :: Type; changes...)
+    structure = mod(;changes...)
+    # TODO: Find a way to use a global scoped function
+    return change(structure;)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,5 +10,8 @@ include("./inputExpressionTests.jl")
 include("./loopAssertionTests.jl")
 include("./loopInputExpressionsTests.jl")
 
+# Structure Invariants
+include("./structInvariantTests.jl")
+
 # Agreement Disabling
 include("./agreementDisablingTests.jl")

--- a/test/structInvariantTests.jl
+++ b/test/structInvariantTests.jl
@@ -1,0 +1,68 @@
+@structInvariant (
+    structure.a < 10,
+    structure.b > 15.0,
+    structure.c == "TestString"
+) struct CoolStructure
+    a :: Int64
+    b :: Float64
+    c :: String
+end
+
+@testset "Evaluates checks on initialization" begin
+    @test initialize(
+        CoolStructure;
+        a = 1, b = 20.0, c = "TestString"
+    ) == CoolStructure(1, 20.0, "TestString")
+
+    @test_throws ContractBreachException initialize(
+        CoolStructure;
+        a = 25, b = 20.0, c = "TestString"
+    ) 
+
+    @test_throws ContractBreachException initialize(
+        CoolStructure;
+        a = 1, b = 2.0, c = "TestString"
+    )
+
+    @test_throws ContractBreachException initialize(
+        CoolStructure;
+        a = 1, b = 20.0, c = "TestString NOT!"
+    )
+end
+
+@testset "Evaluates checks on change" begin
+    cool = initialize(
+        CoolStructure;
+        a = 1, b = 20.0, c = "TestString"
+    )
+
+    @test change(cool; a = 2) == CoolStructure(2, 20.0, "TestString")
+    @test change(cool; b = 30.0) == CoolStructure(1, 30.0, "TestString")
+    @test change(cool; c = "TestString") == CoolStructure(1, 20.0, "TestString")
+
+    @test_throws ContractBreachException change(
+        cool; a = 20
+    ) == CoolStructure(2, 20.0, "TestString")
+    @test_throws ContractBreachException change(
+        cool; b = 3.0
+    ) == CoolStructure(1, 30.0, "TestString")
+    @test_throws ContractBreachException change(
+        cool; c = "TestString NOT!"
+    ) == CoolStructure(1, 20.0, "TestString")
+
+end
+
+setDefaultStructureName(:str)
+
+@structInvariant (structure.a < 10) struct WrongCoolStructure
+    a :: Int64
+end
+
+@structInvariant (str.a < 10) struct NewCoolStructure
+    a :: Int64
+end
+
+@testset "Correctly changes structure name" begin
+    @test initialize(NewCoolStructure; a=1) == NewCoolStructure(1)
+    @test_throws UndefVarError initialize(WrongCoolStructure; a=1)
+end

--- a/test/structInvariantTests.jl
+++ b/test/structInvariantTests.jl
@@ -66,3 +66,17 @@ end
     @test initialize(NewCoolStructure; a=1) == NewCoolStructure(1)
     @test_throws UndefVarError initialize(WrongCoolStructure; a=1)
 end
+
+struct SampleStruct
+    a :: Int64
+end
+
+@testset "Shows error when change isn't implemented for structure" begin
+    try
+        change(SampleStruct; a = 10)
+    catch e
+        b = IOBuffer()
+        showerror(b, e)
+        @test String(take!(b)) == "`change` not implemented for SampleStruct"
+    end
+end


### PR DESCRIPTION
This is a new proposal for the addition of structure invariants. We use `initialize` to instantiate a structure and `change` to change it. It relies 100% on the `Parameters.jl` package.

E.g.

```julia
@structInvariant (
    structure.a < 10,
    structure.b > 15.0,
    structure.c == "TestString"
) struct CoolStructure
    a :: Int64
    b :: Float64
    c :: String
end
```

```julia
cool = initialize(
        CoolStructure;
        a = 1, b = 20.0, c = "TestString"
 )
```
```
| CoolStructure
|   a: Int64 1
|   b: Float64 20.0
|   c: String "TestString"
```

```julia
newCool = change(cool; a = 2)
```
```
| CoolStructure
|   a: Int64 2
|   b: Float64 20.0
|   c: String "TestString"
```
```julia
brokenCool = change(cool; c = "BrokenString")
```
```
| ERROR: ContractBreachException: Breach on Structure Invariant 'structure.c == "TestString"' in function 'CoolStructure'
```

